### PR TITLE
Fix notifications subscription

### DIFF
--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -54,6 +54,7 @@ public final class LRUCache<Key: Hashable, Value> {
     private var values: [Key: Container] = [:]
     private let lock: NSLock = .init()
     private var token: AnyObject?
+    private let notificationCenter: NotificationCenter
 
     /// The current total cost of values in the cache
     public private(set) var totalCost: Int = 0
@@ -69,12 +70,13 @@ public final class LRUCache<Key: Hashable, Value> {
     }
 
     /// Initialize the cache with the specified `totalCostLimit` and `countLimit`
-    public init(totalCostLimit: Int = .max, countLimit: Int = .max) {
+    public init(totalCostLimit: Int = .max, countLimit: Int = .max, notificationCenter: NotificationCenter = .default) {
         self.totalCostLimit = totalCostLimit
         self.countLimit = countLimit
+        self.notificationCenter = notificationCenter
 
         #if canImport(UIKit)
-        self.token = NotificationCenter.default.addObserver(
+        self.token = notificationCenter.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
             queue: nil

--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -85,6 +85,12 @@ public final class LRUCache<Key: Hashable, Value> {
         }
         #endif
     }
+    
+    deinit {
+        if let token = token {
+            notificationCenter.removeObserver(token)
+        }
+    }
 }
 
 public extension LRUCache {

--- a/Tests/LRUCacheTests.swift
+++ b/Tests/LRUCacheTests.swift
@@ -103,5 +103,36 @@ class LRUCacheTests: XCTestCase {
         )
         XCTAssert(cache.isEmpty)
     }
+    
+    func testNotificationObserverIsRemoved() {
+        final class TestNotificationCenter: NotificationCenter {
+            private(set) var observersCount = 0
+            
+            override func addObserver(
+                forName name: NSNotification.Name?,
+                object obj: Any?,
+                queue: OperationQueue?,
+                using block: @escaping (Notification) -> Void) -> NSObjectProtocol {
+                defer { observersCount += 1 }
+                return super.addObserver(forName: name, object: obj, queue: queue, using: block)
+            }
+            
+            override func removeObserver(_ observer: Any) {
+                super.removeObserver(observer)
+                observersCount -= 1
+            }
+        }
+        
+        let notificationCenter = TestNotificationCenter()
+        var cache: LRUCache? = LRUCache<Int, Int>(notificationCenter: notificationCenter)
+        weak var weakCache = cache
+        
+        XCTAssertEqual(1, notificationCenter.observersCount)
+
+        cache = nil
+        XCTAssertNil(weakCache)
+        
+        XCTAssertEqual(0, notificationCenter.observersCount)
+    }
     #endif
 }


### PR DESCRIPTION
Hi 👋 

I like idea of this simple cache 🙂

I just came across it and realized it doesn't properly unregister from `NotificationCenter`. Based on [documentation](https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver#return_value) the token returned by [`addObserver(forName:object:queue:using:)`](https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver) the subscription doesn't end when token is deallocated, but it still needs to be unregistered (really stupid that someone in Apple thinks this is good).

So I added unregistration to deinit and test for it 😎 

Btw. don't like that force push a moment ago 😂 