### PR TITLE
Add subscript

### DIFF
--- a/LRUCache.xcodeproj/project.pbxproj
+++ b/LRUCache.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -157,7 +157,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1330;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = "Nick Lockwood";
 				TargetAttributes = {
 					016FAB2821BFE78100AF60DC = {
@@ -209,6 +209,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		01F2A9E9250177730081CDF5 /* Format Code */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -227,6 +228,7 @@
 		};
 		0A24014C256AA09600C1535C /* Format Code */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -310,6 +312,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -377,6 +380,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -408,6 +412,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -441,6 +446,7 @@
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -473,6 +479,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -495,6 +502,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/LRUCache.xcodeproj/xcshareddata/xcschemes/LRUCache.xcscheme
+++ b/LRUCache.xcodeproj/xcshareddata/xcschemes/LRUCache.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ This would create a cache of unlimited size, containing `Int` values keyed by `S
 
 ```swift
 cache.setValue(99, forKey: "foo")
+cache["foo"] = 99
 ```
 
 To fetch a cached value, use:
 
 ```swift
-let value = cache.value(forKey: "foo") // Returns nil if value not found
+// Returns nil if value not found
+let value = cache.value(forKey: "foo")
+let value = cache["foo"]
 ```
 
 You can limit the cache size either by count or by *cost*. This can be done at initialization time:
@@ -68,18 +71,14 @@ The cost is an arbitrary measure of size, defined by your application. For a fil
 
 ```swift
 cache.setValue(data, forKey: "foo", cost: data.count)
+cache["foo"] = data
 ```
 
 Values will be removed from the cache automatically when either the count or cost limits are exceeded. You can also remove values explicitly by using:
 
 ```swift
 let value = cache.removeValue(forKey: "foo")
-```
-
-Or, if you don't need the value, by setting it to `nil`:
-
-```swift
-cache.setValue(nil, forKey: "foo")
+cache["foo"] = nil
 ```
 
 And you can remove all values at once with:

--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -145,12 +145,13 @@ public extension LRUCache {
     }
     
     /// Insert a value into the cache with optional `cost`
+    @available(*, deprecated, message: "For API clarity, use removeValue(forKey:) instead.")
     func setValue(_ value: Value?, forKey key: Key, cost: Int = 0) {
         guard let value = value else {
             removeValue(forKey: key)
             return
         }
-        setValue(value, forKey: key)
+        setValue(value, forKey: key, cost: cost)
     }
 
     /// Remove a value  from the cache and return it

--- a/Tests/LRUCacheTests.swift
+++ b/Tests/LRUCacheTests.swift
@@ -9,7 +9,7 @@
 import LRUCache
 import XCTest
 
-class LRUCacheTests: XCTestCase {
+final class LRUCacheTests: XCTestCase {
     func testCountLimit() {
         let cache = LRUCache<Int, Int>(countLimit: 2)
         cache.setValue(0, forKey: 0)
@@ -64,7 +64,7 @@ class LRUCacheTests: XCTestCase {
         XCTAssertEqual(cache.removeValue(forKey: 0), 0)
         XCTAssertEqual(cache.count, 1)
         XCTAssertNil(cache.removeValue(forKey: 0))
-        cache.setValue(nil, forKey: 1)
+        cache.removeValue(forKey: 1)
         XCTAssert(cache.isEmpty)
     }
 

--- a/Tests/LRUPerformanceTests.swift
+++ b/Tests/LRUPerformanceTests.swift
@@ -9,14 +9,14 @@
 import LRUCache
 import XCTest
 
-class LRUPerformanceTests: XCTestCase {
+final class LRUPerformanceTests: XCTestCase {
     let iterations = 10000
 
     func testInsertionPerformance() {
         measure {
             let cache = LRUCache<Int, Int>()
             for i in 0 ..< iterations {
-                cache.setValue(i, forKey: i)
+                cache[i] = i
             }
         }
     }
@@ -24,11 +24,11 @@ class LRUPerformanceTests: XCTestCase {
     func testLookupPerformance() {
         let cache = LRUCache<Int, Int>()
         for i in 0 ..< iterations {
-            cache.setValue(i, forKey: i)
+            cache[i] = i
         }
         measure {
             for i in 0 ..< iterations {
-                _ = cache.value(forKey: i)
+                _ = cache[i]
             }
         }
     }
@@ -49,7 +49,7 @@ class LRUPerformanceTests: XCTestCase {
         measure {
             let cache = LRUCache<Int, Int>(countLimit: 1000)
             for i in 0 ..< iterations {
-                cache.setValue(i, forKey: i)
+                cache[i] = i
             }
         }
     }


### PR DESCRIPTION
Add subscript for easy access to cache:
```swift
subscript(_ key: Key) -> Value?

// usage:
cache[key] = value
// remove value from cache:
cache[key] = nil
```

Add a function overload for `setValue`, old function still remain to prevent source breaking change:
```swift
// not recommended, use removeValue(forKey:) instead.
func setValue(_ value: Value?, forKey key: Key, cost: Int)

func setValue(_ value: Value, forKey key: Key, cost: Int)
```


Reserve capacity for `values` when init.