### PR TITLE
Fix: removeAllValues method in totalCost reset

### DIFF
--- a/LRUCache.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LRUCache.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/LRUCache.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LRUCache.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -190,6 +190,7 @@ public extension LRUCache {
         values.removeAll()
         head = nil
         tail = nil
+        totalCost = 0
         lock.unlock()
     }
 }

--- a/Tests/LRUCacheTests.swift
+++ b/Tests/LRUCacheTests.swift
@@ -70,12 +70,14 @@ class LRUCacheTests: XCTestCase {
 
     func testRemoveAllValues() {
         let cache = LRUCache<Int, Int>(totalCostLimit: 2)
-        cache.setValue(0, forKey: 0)
-        cache.setValue(1, forKey: 1)
+        cache.setValue(0, forKey: 0, cost: 1)
+        cache.setValue(1, forKey: 1, cost: 1)
         cache.removeAllValues()
         XCTAssert(cache.isEmpty)
-        cache.setValue(0, forKey: 0)
+        XCTAssertEqual(cache.totalCost, 0)
+        cache.setValue(0, forKey: 0, cost: 1)
         XCTAssertEqual(cache.count, 1)
+        XCTAssertEqual(cache.totalCost, 1)
     }
 
     func testAllValues() {


### PR DESCRIPTION
Currently, totalCost is not initialized in removeAllValue. So I added the code and tests.