### PR TITLE
Improve visionOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ And you can remove all values at once with:
 cache.removeAllValues()
 ```
 
-On iOS and tvOS, the cache will be emptied automatically in the event of a memory warning.
+On platforms where UIKit is available (iOS, tvOS, and visionOS), the cache will be emptied automatically in the event of a memory warning.
 
 
 # Concurrency

--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -33,7 +33,7 @@
 
 import Foundation
 
-#if os(iOS) || os(tvOS)
+#if canImport(UIKit)
 import UIKit
 
 /// Notification that cache should be cleared


### PR DESCRIPTION
This PR improves visionOS support. Previously visionOS wouldn't use the `UIApplication.didReceiveMemoryWarningNotification` notification name, since the `#if os` condition only included iOS and visionOS.

I typically find it to be better to use `#if canImport(UIKit)` rather than explicitly enumerating the list of platforms that use UIKit, since this is more future-proof. Alternatively we could use `#if os(iOS) || os(tvOS) || os(visionOS)`.