### PR TITLE
Fix watchOS compiler error

### DIFF
--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -33,7 +33,7 @@
 
 import Foundation
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 import UIKit
 
 /// Notification that cache should be cleared


### PR DESCRIPTION
PR #12 introduced a compiler error for Apple Watch apps. watchOS can import the `UIKit` framework, but the symbol `didReceiveMemoryWarningNotification` is unavailable on this platform.

https://developer.apple.com/documentation/uikit/uiapplication/1622920-didreceivememorywarningnotificat#