### PR TITLE
Use DispatchSourceMemoryPressure on supported platforms

### DIFF
--- a/Sources/LRUCache.swift
+++ b/Sources/LRUCache.swift
@@ -54,11 +54,11 @@ public final class LRUCache<Key: Hashable & Sendable, Value>: @unchecked Sendabl
     private unowned(unsafe) var head: Container?
     private unowned(unsafe) var tail: Container?
     private let lock: NSLock = .init()
-    private var token: AnyObject?
-
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    private let memoryPressureSource: DispatchSourceMemoryPressure
+    #endif
+    
     #if !os(WASI)
-
-    private let notificationCenter: NotificationCenter
 
     /// Initialize the cache with the specified `totalCostLimit` and `countLimit`
     public init(
@@ -68,19 +68,22 @@ public final class LRUCache<Key: Hashable & Sendable, Value>: @unchecked Sendabl
     ) {
         self._totalCostLimit = totalCostLimit
         self._countLimit = countLimit
-        self.notificationCenter = notificationCenter
-
-        self.token = notificationCenter.addObserver(
-            forName: LRUCacheMemoryWarningNotification,
-            object: nil,
-            queue: nil
-        ) { [weak self] _ in
+        
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+        self.memoryPressureSource = DispatchSource
+            .makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .global())
+        self.memoryPressureSource.setEventHandler {
+            [weak self] in
             self?.removeAll()
         }
+        self.memoryPressureSource.resume()
+        #endif
     }
-
+    
     deinit {
-        token.map(notificationCenter.removeObserver)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
+        self.memoryPressureSource.cancel()
+        #endif
     }
 
     #else


### PR DESCRIPTION
Add support for `DispatchSourceMemoryPressure`. Unfortunately, as discussed in #3, I was not able to provide a reliable unit test.