### PR TITLE
Add clearsOnMemoryPressure parameter

### DIFF
--- a/Tests/LRUCacheTests.swift
+++ b/Tests/LRUCacheTests.swift
@@ -154,6 +154,21 @@ class LRUCacheTests: XCTestCase {
     }
 
     @available(*, deprecated, message: "Obsolete")
+    func testClearsOnMemoryPressureDisabled() {
+        let cache = LRUCache<Int, Int>(clearsOnMemoryPressure: false)
+        for i in 0 ..< 100 {
+            cache.setValue(i, forKey: i)
+        }
+        XCTAssertEqual(cache.count, 100)
+        NotificationCenter.default.post(
+            name: LRUCacheMemoryWarningNotification,
+            object: nil
+        )
+        // Cache should NOT be cleared when clearsOnMemoryPressure is false
+        XCTAssertEqual(cache.count, 100)
+    }
+
+    @available(*, deprecated, message: "Obsolete")
     func testNotificationObserverIsRemoved() {
         #if !os(Linux)
         final class TestNotificationCenter: NotificationCenter, @unchecked Sendable {


### PR DESCRIPTION
This PR adds a new `clearsOnMemoryPressure` parameter to the `LRUCache` initializer, allowing callers to opt out of automatic cache clearing on memory pressure events.

## Motivation

The current behavior clears the entire cache on any memory pressure event (including `.warning`). While this is sensible for caches storing computed or regenerable data, it can cause issues for caches that are backed by persistent storage (like a database).

In these cases, a cache miss after memory pressure leads to empty results instead of triggering a refetch—the calling code has no way to distinguish "this key was never cached" from "this key was evicted due to memory pressure."

By allowing callers to disable memory pressure clearing, they can choose the appropriate behavior for their use case:
- `clearsOnMemoryPressure: true` (default) — for computed/regenerable data where clearing is safe
- `clearsOnMemoryPressure: false` — for database-backed caches where the LRU eviction policy should be the only eviction mechanism

## Changes

- Added `clearsOnMemoryPressure: Bool = true` parameter to the initializer
- Made `memoryPressureSource` optional and only initialized when the parameter is `true`
- Also skips registering for the deprecated notification when `false`
- Added a unit test for the new behavior

## Backward Compatibility

The parameter defaults to `true`, so existing code continues to work unchanged.